### PR TITLE
Add a full object-parsing test for Java.

### DIFF
--- a/JSON.java
+++ b/JSON.java
@@ -1,28 +1,45 @@
 import java.io.*;
 import java.util.Date;
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class JSON {
   public static void main(String[] args) throws IOException, JsonParseException {
-    long start = new Date().getTime();
+    boolean tokenizeOnly = false;
+    if (args.length >= 1 && "tokenize".equalsIgnoreCase(args[0]))
+       tokenizeOnly = true;
+
+    System.out.println("Running " + (tokenizeOnly ? "tokenize" : "full") + " test");
+
     BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
-    JsonFactory factory = new JsonFactory();
-    JsonParser parser = null;
     long bytesRead = 0;
     String s;
-    while ((s = in.readLine()) != null && s.length() != 0) {
-      bytesRead += s.length();
-      parser = factory.createJsonParser(s);
-      while(parser.nextToken() != null) {
-         // do nothing
+
+    long start = new Date().getTime();
+    if (tokenizeOnly) {
+      JsonFactory factory = new JsonFactory();
+      JsonParser parser = null;
+      while ((s = in.readLine()) != null && s.length() != 0) {
+        bytesRead += s.length();
+        parser = factory.createJsonParser(s);
+        while(parser.nextToken() != null) {
+           // do nothing
+        }
+      }
+    } else {
+      ObjectMapper jsonMapper = new ObjectMapper();
+      ObjectNode document;
+      while ((s = in.readLine()) != null && s.length() != 0) {
+        bytesRead += s.length();
+        document = jsonMapper.readValue(s, ObjectNode.class);
       }
     }
     long end = new Date().getTime();
 
     long duration = end - start;
-    double mbPerSec = ((double)bytesRead / 1024.0 / 1024.0) / (duration / 1000.0);
-    System.out.println(String.format("Processing %d bytes took %d ms (%.2f MB/s)", bytesRead, duration, mbPerSec));
+    double durationSec = (duration / 1000.0);
+    double mbPerSec = ((double)bytesRead / 1024.0 / 1024.0) / durationSec;
+    System.out.println(String.format("%.2f MB/s %d bytes in %.2f s", mbPerSec, bytesRead, durationSec));
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-JARS=jackson-core-2.1.4.jar
+JARS=jackson-core-2.1.4.jar jackson-databind-2.1.4.jar jackson-annotations-2.1.4.jar
 space :=
 space +=
 comma :=,
@@ -34,7 +34,7 @@ json: json.cpp json.h rapidjson
 
 go:
 	go install jsonbench
-	${GOPATH}/bin/jsonbench $(JSON)
+	$(GOPATH)/bin/jsonbench $(JSON)
 
 rust:
 	rustc -O rust.rs && ./rust  < $(JSON)
@@ -51,11 +51,23 @@ cxx-proc: $(CPUS)
 cxx: json
 	 ./json < $(JSON)
 
-java: $(JARS)
-	javac -cp $(JARS_CP)  JSON.java && java -cp $(JARS_CP):. JSON < $(JSON)
+javac: $(JARS)
+	javac -cp $(JARS_CP) JSON.java
+
+java: javac
+	java -cp $(JARS_CP):. JSON < $(JSON)
+
+java_tokenize: javac
+	java -cp $(JARS_CP):. JSON tokenize < $(JSON)
 
 jackson-core-2.1.4.jar:
 	wget -c http://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.1.4/jackson-core-2.1.4.jar
+
+jackson-databind-2.1.4.jar:
+	wget -c http://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.1.4/jackson-databind-2.1.4.jar
+
+jackson-annotations-2.1.4.jar:
+	wget -c http://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.1.4/jackson-annotations-2.1.4.jar
 
 jython-standalone-2.7-b1.jar:
 	wget -c http://repo1.maven.org/maven2/org/python/jython-standalone/2.7-b1/jython-standalone-2.7-b1.jar


### PR DESCRIPTION
The 'java' target now fully parses json into objects.
There is a 'java_tokenize' target to run the tokenize-only test that used to
be the default java test.
